### PR TITLE
08 inherited widget failing build fix

### DIFF
--- a/08_inherited_widgets/lib/main.dart
+++ b/08_inherited_widgets/lib/main.dart
@@ -55,7 +55,7 @@ class _NamePageState extends State<NamePage> {
   // Fetch a name asynchonously over HTTP
   _get() async {
     var res = await http.get('https://jsonplaceholder.typicode.com/users');
-    var name = JSON.decode(res.body)[0]['name'];
+    var name = json.decode(res.body)[0]['name'];
     setState(() => this.name = name);
   }
 

--- a/08_inherited_widgets/pubspec.yaml
+++ b/08_inherited_widgets/pubspec.yaml
@@ -8,7 +8,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.0
-
+  http: ^0.11.3  
+  
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
http package was missing from pubspec.yaml which was added
json was written as JSON in main.dart which was corrected to lower case